### PR TITLE
fix: overlayfs take over lower dir permissions

### DIFF
--- a/meta/files/overlayfs-create-dirs.sh
+++ b/meta/files/overlayfs-create-dirs.sh
@@ -8,4 +8,5 @@ mkdir -p ${datamountpoint}/upper${lowerdir}
 mkdir -p ${datamountpoint}/workdir${lowerdir}
 if [ -d "$lowerdir" ]; then
     chown $(stat -c "%U:%G" ${lowerdir}) ${datamountpoint}/upper${lowerdir}
+    chmod $(stat -c "%a" ${lowerdir}) ${datamountpoint}/upper${lowerdir}
 fi


### PR DESCRIPTION
when creating the upper dir directories using the
overlayfs-create-dirs.sh script in addition to take over the ownership of the lower dir to the upper dir also take over the lower dir permissions.

[]